### PR TITLE
Refactor parse mode handling for Telegram actions

### DIFF
--- a/actions.py
+++ b/actions.py
@@ -16,6 +16,8 @@ import httpx
 from jinja2 import Environment, StrictUndefined
 from jinja2.sandbox import SandboxedEnvironment
 
+from .parse_mode import resolve_parse_mode
+
 try:
     import jmespath
 except ImportError:  # 可选依赖
@@ -212,7 +214,7 @@ class ActionExecutor:
                 success=True,
                 should_edit_message=bool(result_dict.get("new_text")),
                 new_text=result_dict.get("new_text"),
-                parse_mode=self._map_parse_mode(result_dict.get("parse_mode", "html")),
+                parse_mode=resolve_parse_mode(result_dict.get("parse_mode", "html")),
                 next_menu_id=result_dict.get("next_menu_id"),
                 button_overrides=result_dict.get("button_overrides", []),
                 notification=result_dict.get("notification"),
@@ -707,7 +709,7 @@ class ActionExecutor:
                 success=True,
                 should_edit_message=bool(result.get("new_text")),
                 new_text=result.get("new_text"),
-                parse_mode=self._map_parse_mode(result.get("parse_mode", "html")),
+                parse_mode=resolve_parse_mode(result.get("parse_mode", "html")),
                 next_menu_id=result.get("next_menu_id"),
                 button_overrides=result.get("button_overrides", []),
                 notification=result.get("notification"),
@@ -1137,7 +1139,7 @@ class ActionExecutor:
             parse_mode_alias = str(render_cfg.get("format", "html")).lower()
             should_edit = bool(render_cfg.get("update_message", True))
             next_menu_id = render_cfg.get("next_menu_id")
-        parse_mode = self._map_parse_mode(parse_mode_alias)
+        parse_mode = resolve_parse_mode(parse_mode_alias)
         button_title_template = render_cfg.get("button_title_template")
         overrides_cfg: List[Dict[str, Any]] = []
         if isinstance(message_cfg, dict) and message_cfg.get("button_overrides"):
@@ -1192,15 +1194,6 @@ class ActionExecutor:
             button_title=overrides_self_text,
             button_overrides=overrides,
         )
-
-    def _map_parse_mode(self, alias: str) -> Optional[str]:
-        if alias in {"markdown", "md"}:
-            return "Markdown"
-        if alias in {"markdownv2", "mdv2"}:
-            return "MarkdownV2"
-        if alias == "html":
-            return "HTML"
-        return None
 
     async def _aapply_extractor(
         self, extractor_type: str, expression: str, response: Optional[httpx.Response]

--- a/local_actions/__init__.py
+++ b/local_actions/__init__.py
@@ -1,0 +1,1 @@
+"""Helper package for built-in local Telegram actions."""

--- a/local_actions/_message_utils.py
+++ b/local_actions/_message_utils.py
@@ -1,0 +1,59 @@
+"""Shared helpers for local Telegram message actions."""
+from __future__ import annotations
+
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Any, Iterator, Optional
+
+from ..parse_mode import (
+    DEFAULT_PARSE_MODE,
+    DEFAULT_PARSE_MODE_ALIAS,
+    PARSE_MODE_OPTION_LABELS,
+    PARSE_MODE_OPTIONS,
+    ensure_parse_mode_alias,
+    resolve_parse_mode,
+)
+
+__all__ = [
+    "DEFAULT_PARSE_MODE_ALIAS",
+    "PARSE_MODE_OPTION_LABELS",
+    "PARSE_MODE_OPTIONS",
+    "coerce_parse_mode_for_api",
+    "ensure_parse_mode_alias",  # re-export for convenience
+    "ensure_parse_mode_alias_or_default",
+    "open_binary_file",
+    "require_client",
+]
+
+
+@contextmanager
+def open_binary_file(path: str, description: str) -> Iterator[Any]:
+    """Open *path* as binary stream, raising a RuntimeError on failure."""
+    file_path = Path(path)
+    if not file_path.is_file():
+        raise RuntimeError(f"{description}文件不存在: {path}")
+
+    try:
+        with file_path.open("rb") as handle:
+            yield handle
+    except OSError as exc:  # pragma: no cover - defensive logging wrapper
+        raise RuntimeError(f"读取{description}文件失败: {exc}") from exc
+
+
+def require_client(plugin: Any) -> Any:
+    """Fetch the Telegram client from *plugin* or raise a RuntimeError."""
+    client = plugin._get_telegram_client()  # noqa: SLF001 - private helper access is expected
+    if not client:
+        raise RuntimeError("无法获取 Telegram 客户端实例。")
+    return client
+
+
+def coerce_parse_mode_for_api(value: Optional[str]) -> Optional[str]:
+    """Convert a parse mode alias into the Telegram constant used by the API."""
+    alias = ensure_parse_mode_alias(value)
+    return resolve_parse_mode(alias, default=DEFAULT_PARSE_MODE)
+
+
+def ensure_parse_mode_alias_or_default(value: Optional[str]) -> str:
+    """Normalise a parse mode alias, falling back to the plugin default."""
+    return ensure_parse_mode_alias(value)

--- a/local_actions/send_message.py
+++ b/local_actions/send_message.py
@@ -1,10 +1,18 @@
 # local_actions/send_message.py
 
-from typing import TYPE_CHECKING, Dict, Any, List
+from typing import TYPE_CHECKING, Any, Dict
+
+from ._message_utils import (
+    DEFAULT_PARSE_MODE_ALIAS,
+    PARSE_MODE_OPTION_LABELS,
+    PARSE_MODE_OPTIONS,
+    coerce_parse_mode_for_api,
+    open_binary_file,
+    require_client,
+)
 
 if TYPE_CHECKING:
     from ..main import DynamicButtonFrameworkPlugin
-    from ..actions import RuntimeContext
 
 # --- 动作元数据 (新版) ---
 ACTION_METADATA = {
@@ -36,6 +44,15 @@ ACTION_METADATA = {
             "required": True,
             "description": "要发送到的目标聊天 ID。通常从工作流的运行时变量 `runtime.chat_id` 获取。",
         },
+        {
+            "name": "parse_mode",
+            "type": "string",
+            "required": False,
+            "default": DEFAULT_PARSE_MODE_ALIAS,
+            "description": "发送文本或说明文字时使用的 Telegram 解析模式。",
+            "enum": PARSE_MODE_OPTIONS,
+            "enum_labels": PARSE_MODE_OPTION_LABELS,
+        },
     ],
     "outputs": [
         {
@@ -47,54 +64,52 @@ ACTION_METADATA = {
 }
 
 
-# --- 动作执行逻辑---
 async def execute(
     plugin: "DynamicButtonFrameworkPlugin",
     chat_id: str,
-    text: str = None,
+    text: str = "",
     image_source: str = None,
     voice_source: str = None,
+    parse_mode: str = DEFAULT_PARSE_MODE_ALIAS,
 ) -> Dict[str, Any]:
-    """
-    【已重构】立即执行发送消息的操作，并返回 message_id。
-    """
-    # 1. 获取 Telegram 客户端
-    client = plugin._get_telegram_client()
-    if not client:
-        # 在真实执行环境中，最好是通过抛出异常来中断工作流，但这里为了简单，返回一个错误指示
-        # 注意：ActionExecutor 会捕获这个异常并报告错误
-        raise RuntimeError("无法获取 Telegram 客户端实例。")
+    """立即执行发送消息的操作，并返回 message_id。"""
+    client = require_client(plugin)
+    telegram_parse_mode = coerce_parse_mode_for_api(parse_mode)
 
-    # 2. 准备消息内容
     caption = text or ""
     sent_message = None
 
-    # 3. 根据内容调用不同的 API
     try:
         if image_source:
-            with open(image_source, "rb") as photo_payload:
+            with open_binary_file(image_source, "图片") as photo_payload:
                 sent_message = await client.send_photo(
-                    chat_id=chat_id, photo=photo_payload, caption=caption
+                    chat_id=chat_id,
+                    photo=photo_payload,
+                    caption=caption or None,
+                    parse_mode=telegram_parse_mode,
                 )
         elif voice_source:
-            with open(voice_source, "rb") as voice_payload:
+            with open_binary_file(voice_source, "语音") as voice_payload:
                 sent_message = await client.send_voice(
-                    chat_id=chat_id, voice=voice_payload, caption=caption
+                    chat_id=chat_id,
+                    voice=voice_payload,
+                    caption=caption or None,
+                    parse_mode=telegram_parse_mode,
                 )
         elif caption:
-            sent_message = await client.send_message(chat_id=chat_id, text=caption)
+            sent_message = await client.send_message(
+                chat_id=chat_id,
+                text=caption,
+                parse_mode=telegram_parse_mode,
+            )
         else:
-            # 没有发送任何内容，可以选择静默返回或报错
-            return {}  # 返回空字典，表示没有输出
+            return {}
 
-    except Exception as e:
+    except Exception as e:  # pragma: no cover - depends on Telegram connectivity
         plugin.logger.error(f"发送消息时出错: {e}", exc_info=True)
         raise RuntimeError(f"调用 Telegram API 发送消息失败: {e}")
 
-    # 4. 如果发送成功，提取并返回 message_id
     if sent_message and hasattr(sent_message, "message_id"):
-        message_id = sent_message.message_id
-        # 按新规范，将输出变量直接放在返回字典的顶层
-        return {"message_id": message_id}
+        return {"message_id": sent_message.message_id}
 
     return {}

--- a/local_actions/update_message.py
+++ b/local_actions/update_message.py
@@ -1,14 +1,36 @@
+from typing import Dict
+
+from ._message_utils import (
+    DEFAULT_PARSE_MODE_ALIAS,
+    PARSE_MODE_OPTION_LABELS,
+    PARSE_MODE_OPTIONS,
+    ensure_parse_mode_alias_or_default,
+)
+
 ACTION_METADATA = {
     "id": "update_message",
     "name": "更新菜单标题",
     "description": "使用输入的文本更新当前菜单的标题文本。",
     "inputs": [
-        {"name": "text", "type": "string", "description": "要显示的新的菜单标题。"}
+        {"name": "text", "type": "string", "description": "要显示的新的菜单标题。"},
+        {
+            "name": "parse_mode",
+            "type": "string",
+            "required": False,
+            "default": DEFAULT_PARSE_MODE_ALIAS,
+            "description": "渲染菜单标题时使用的 Telegram 解析模式。",
+            "enum": PARSE_MODE_OPTIONS,
+            "enum_labels": PARSE_MODE_OPTION_LABELS,
+        },
     ],
     "outputs": [],
 }
 
 
-async def execute(text: str) -> dict:
+async def execute(text: str, parse_mode: str = DEFAULT_PARSE_MODE_ALIAS) -> Dict[str, str]:
     """将输入的文本作为 new_text 返回以更新菜单标题。"""
-    return {"new_text": text}
+    normalised_mode = ensure_parse_mode_alias_or_default(parse_mode)
+    result: Dict[str, str] = {"new_text": text}
+    if text:
+        result["parse_mode"] = normalised_mode
+    return result

--- a/main.py
+++ b/main.py
@@ -58,6 +58,7 @@ from .storage import (
     MenuDefinition,
     WebAppDefinition,
 )
+from .parse_mode import ensure_parse_mode_alias, resolve_parse_mode
 from .modular_actions import ModularActionRegistry
 
 
@@ -439,19 +440,8 @@ class DynamicButtonFrameworkPlugin(Star):
                 "user_input_is_cancelled": False,
             }
 
-        def _map_parse_mode(value: Optional[str]) -> Optional[str]:
-            if not value:
-                return "HTML"
-            lowered = value.strip().lower()
-            if lowered in ("", "none", "plain"):
-                return None
-            if lowered in ("markdownv2", "mdv2"):
-                return "MarkdownV2"
-            if lowered in ("markdown", "md"):
-                return "Markdown"
-            return "HTML"
-
-        parse_mode_value = (parse_mode or "html").strip().lower()
+        parse_mode_alias = ensure_parse_mode_alias(parse_mode)
+        parse_mode_value = parse_mode_alias
 
         def _normalize_button_label(raw_text: Optional[str], fallback: Optional[str] = None) -> str:
             base_text = str(raw_text or "").strip()
@@ -472,7 +462,7 @@ class DynamicButtonFrameworkPlugin(Star):
                 base_text = base_text[:61] + "..."
             return base_text
 
-        tg_parse_mode = _map_parse_mode(parse_mode)
+        tg_parse_mode = resolve_parse_mode(parse_mode_alias, default="HTML")
         prompt_text = prompt or "请输入内容："
 
         display_mode_value = str(display_mode or "button_label").strip().lower()
@@ -851,11 +841,11 @@ class DynamicButtonFrameworkPlugin(Star):
 
         if menu_title_mode and final_text:
             result["new_text"] = final_text
-            result["parse_mode"] = parse_mode or "html"
+            result["parse_mode"] = parse_mode_alias
             result["should_edit_message"] = True
         elif final_text and not button_label_mode:
             result["new_text"] = final_text
-            result["parse_mode"] = parse_mode or "html"
+            result["parse_mode"] = parse_mode_alias
 
         if button_overrides:
             result["button_overrides"] = button_overrides

--- a/parse_mode.py
+++ b/parse_mode.py
@@ -1,0 +1,77 @@
+"""Utility helpers for handling Telegram parse modes across the plugin."""
+from __future__ import annotations
+
+from typing import Optional
+
+PARSE_MODE_OPTIONS = ["html", "markdown", "markdownv2", "none"]
+"""Supported parse mode aliases exposed to configuration/UI layers."""
+
+PARSE_MODE_OPTION_LABELS = {
+    "html": "HTML",
+    "markdown": "Markdown",
+    "markdownv2": "Markdown V2",
+    "none": "纯文本",
+}
+"""Human readable labels for the parse mode options."""
+
+DEFAULT_PARSE_MODE_ALIAS = PARSE_MODE_OPTIONS[0]
+"""Default parse mode alias used when none is provided."""
+
+
+def ensure_parse_mode_alias(value: Optional[str]) -> str:
+    """Return a normalised parse mode alias recognised by the plugin."""
+    alias = str(value or "").strip().lower()
+    if alias in PARSE_MODE_OPTIONS:
+        return alias
+    return DEFAULT_PARSE_MODE_ALIAS
+
+
+def resolve_parse_mode(value: Optional[str], *, default: Optional[str] = None) -> Optional[str]:
+    """
+    Convert a user provided parse mode alias into the Telegram API constant.
+
+    The helper understands the aliases we surface in the UI (``html``, ``markdown``,
+    ``markdownv2`` and ``none``) as well as the canonical Telegram constants.
+    Unknown values fall back to ``default`` so callers can decide whether to keep
+    the previous value or reset to ``None``.
+    """
+
+    if value is None:
+        return default
+
+    alias = str(value).strip()
+    if not alias:
+        return default
+
+    lowered = alias.lower()
+    if lowered in {"", "plain", "text", "none", "disabled"}:
+        return None
+
+    mapping = {
+        "html": "HTML",
+        "markdown": "Markdown",
+        "md": "Markdown",
+        "markdownv2": "MarkdownV2",
+        "mdv2": "MarkdownV2",
+    }
+    if lowered in mapping:
+        return mapping[lowered]
+
+    if alias in {"HTML", "Markdown", "MarkdownV2"}:
+        return alias
+
+    return default
+
+
+DEFAULT_PARSE_MODE = resolve_parse_mode(DEFAULT_PARSE_MODE_ALIAS, default="HTML")
+"""Default Telegram parse mode constant corresponding to ``DEFAULT_PARSE_MODE_ALIAS``."""
+
+
+__all__ = [
+    "DEFAULT_PARSE_MODE",
+    "DEFAULT_PARSE_MODE_ALIAS",
+    "PARSE_MODE_OPTION_LABELS",
+    "PARSE_MODE_OPTIONS",
+    "ensure_parse_mode_alias",
+    "resolve_parse_mode",
+]


### PR DESCRIPTION
## Summary
- extract shared parse mode utilities and reuse them across the action executor and wait-for-input flow
- add common local action helpers and extend send/edit/update message actions to expose parse mode dropdowns
- apply the selected parse mode when sending or editing Telegram messages

## Testing
- python -m py_compile parse_mode.py local_actions/_message_utils.py local_actions/send_message.py local_actions/edit_message_text.py local_actions/edit_message_media.py local_actions/update_message.py actions.py main.py

------
https://chatgpt.com/codex/tasks/task_b_68f0b3bd44a483268fd14e0a323aea35