### PR TITLE
Add shared Telegram parse mode helpers and extend message actions

### DIFF
--- a/actions.py
+++ b/actions.py
@@ -16,6 +16,8 @@ import httpx
 from jinja2 import Environment, StrictUndefined
 from jinja2.sandbox import SandboxedEnvironment
 
+from .telegram_format import map_to_telegram_parse_mode
+
 try:
     import jmespath
 except ImportError:  # 可选依赖
@@ -212,7 +214,7 @@ class ActionExecutor:
                 success=True,
                 should_edit_message=bool(result_dict.get("new_text")),
                 new_text=result_dict.get("new_text"),
-                parse_mode=self._map_parse_mode(result_dict.get("parse_mode", "html")),
+                parse_mode=map_to_telegram_parse_mode(result_dict.get("parse_mode", "html")),
                 next_menu_id=result_dict.get("next_menu_id"),
                 button_overrides=result_dict.get("button_overrides", []),
                 notification=result_dict.get("notification"),
@@ -707,7 +709,7 @@ class ActionExecutor:
                 success=True,
                 should_edit_message=bool(result.get("new_text")),
                 new_text=result.get("new_text"),
-                parse_mode=self._map_parse_mode(result.get("parse_mode", "html")),
+                parse_mode=map_to_telegram_parse_mode(result.get("parse_mode", "html")),
                 next_menu_id=result.get("next_menu_id"),
                 button_overrides=result.get("button_overrides", []),
                 notification=result.get("notification"),
@@ -1137,7 +1139,7 @@ class ActionExecutor:
             parse_mode_alias = str(render_cfg.get("format", "html")).lower()
             should_edit = bool(render_cfg.get("update_message", True))
             next_menu_id = render_cfg.get("next_menu_id")
-        parse_mode = self._map_parse_mode(parse_mode_alias)
+        parse_mode = map_to_telegram_parse_mode(parse_mode_alias)
         button_title_template = render_cfg.get("button_title_template")
         overrides_cfg: List[Dict[str, Any]] = []
         if isinstance(message_cfg, dict) and message_cfg.get("button_overrides"):
@@ -1192,15 +1194,6 @@ class ActionExecutor:
             button_title=overrides_self_text,
             button_overrides=overrides,
         )
-
-    def _map_parse_mode(self, alias: str) -> Optional[str]:
-        if alias in {"markdown", "md"}:
-            return "Markdown"
-        if alias in {"markdownv2", "mdv2"}:
-            return "MarkdownV2"
-        if alias == "html":
-            return "HTML"
-        return None
 
     async def _aapply_extractor(
         self, extractor_type: str, expression: str, response: Optional[httpx.Response]

--- a/local_actions/update_message.py
+++ b/local_actions/update_message.py
@@ -1,14 +1,22 @@
+from ..telegram_format import build_parse_mode_input, canonical_parse_mode_alias
+
+
 ACTION_METADATA = {
     "id": "update_message",
     "name": "更新菜单标题",
     "description": "使用输入的文本更新当前菜单的标题文本。",
     "inputs": [
-        {"name": "text", "type": "string", "description": "要显示的新的菜单标题。"}
+        {"name": "text", "type": "string", "description": "要显示的新的菜单标题。"},
+        build_parse_mode_input(
+            description="更新菜单标题时使用的 Telegram 解析模式。",
+            default="html",
+        ),
     ],
     "outputs": [],
 }
 
 
-async def execute(text: str) -> dict:
+async def execute(text: str, parse_mode: str = "html") -> dict:
     """将输入的文本作为 new_text 返回以更新菜单标题。"""
-    return {"new_text": text}
+    alias = canonical_parse_mode_alias(parse_mode)
+    return {"new_text": text, "parse_mode": alias}

--- a/telegram_format.py
+++ b/telegram_format.py
@@ -1,0 +1,66 @@
+"""Utility helpers for Telegram parse mode handling and metadata generation."""
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+
+# Canonical enum values that are exposed to the WebUI/metadata layer.
+PARSE_MODE_ENUM = ("html", "markdown", "markdownv2", "none")
+
+# Human readable labels for the dropdown list.
+PARSE_MODE_LABELS: Dict[str, str] = {
+    "html": "HTML",
+    "markdown": "Markdown",
+    "markdownv2": "Markdown V2",
+    "none": "纯文本",
+}
+
+# Mapping from canonical enum value to Telegram Bot API parse mode string.
+_PARSE_MODE_TO_TELEGRAM: Dict[str, Optional[str]] = {
+    "html": "HTML",
+    "markdown": "Markdown",
+    "markdownv2": "MarkdownV2",
+    "none": None,
+}
+
+# Aliases that should resolve to the same canonical enum value.
+_ALIAS_TO_CANONICAL: Dict[str, str] = {
+    "html": "html",
+    "": "html",
+    "plain": "none",
+    "none": "none",
+    "markdown": "markdown",
+    "md": "markdown",
+    "markdownv2": "markdownv2",
+    "mdv2": "markdownv2",
+}
+
+
+def canonical_parse_mode_alias(value: Optional[str], *, default: str = "html") -> str:
+    """Return the canonical enum value for the provided parse mode alias."""
+    candidate = str(value or "").strip().lower()
+    if candidate in _ALIAS_TO_CANONICAL:
+        return _ALIAS_TO_CANONICAL[candidate]
+    # Fallback to default when the value is not recognised.
+    if default not in PARSE_MODE_ENUM:
+        default = "html"
+    return default
+
+
+def map_to_telegram_parse_mode(value: Optional[str], *, default: str = "html") -> Optional[str]:
+    """Resolve an alias to the Telegram parse mode string accepted by the API."""
+    alias = canonical_parse_mode_alias(value, default=default)
+    return _PARSE_MODE_TO_TELEGRAM.get(alias)
+
+
+def build_parse_mode_input(*, description: str, default: str = "html", required: bool = False) -> Dict[str, Any]:
+    """Return a metadata entry describing a parse mode dropdown input."""
+    alias_default = canonical_parse_mode_alias(default)
+    return {
+        "name": "parse_mode",
+        "type": "string",
+        "required": required,
+        "default": alias_default,
+        "description": description,
+        "enum": list(PARSE_MODE_ENUM),
+        "enum_labels": dict(PARSE_MODE_LABELS),
+    }


### PR DESCRIPTION
## Summary
- centralize Telegram parse mode resolution and reuse it across the executor and runtime helpers
- extend send/edit/update message local actions with dropdown parse mode metadata and API support for Telegram formatting
- adjust workflow messaging utilities to honour the new parse mode handling

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_b_68f0b3bd44a483268fd14e0a323aea35