### PR TITLE
调整模块化动作的消息更新判定逻辑

### DIFF
--- a/actions.py
+++ b/actions.py
@@ -205,16 +205,23 @@ class ActionExecutor:
                     "notification",
                     "new_message_chain",
                     "temp_files_to_clean",
+                    "button_title",
                 ]
             }
 
             return ActionExecutionResult(
                 success=True,
-                should_edit_message=bool(result_dict.get("new_text")),
+                should_edit_message=bool(
+                    result_dict.get("new_text")
+                    or result_dict.get("next_menu_id")
+                    or result_dict.get("button_overrides")
+                    or result_dict.get("button_title")
+                ),
                 new_text=result_dict.get("new_text"),
                 parse_mode=self._map_parse_mode(result_dict.get("parse_mode", "html")),
                 next_menu_id=result_dict.get("next_menu_id"),
                 button_overrides=result_dict.get("button_overrides", []),
+                button_title=result_dict.get("button_title"),
                 notification=result_dict.get("notification"),
                 new_message_chain=result_dict.get("new_message_chain"),
                 temp_files_to_clean=result_dict.get("temp_files_to_clean", []),
@@ -300,6 +307,9 @@ class ActionExecutor:
             final_result.button_overrides.extend(
                 result.button_overrides
             )  # 按钮覆盖，全部累加
+
+        if result.button_title:
+            final_result.button_title = result.button_title
 
     async def _execute_workflow_node(
         self,
@@ -621,6 +631,7 @@ class ActionExecutor:
                 final_result.new_text
                 or final_result.next_menu_id
                 or final_result.button_overrides
+                or final_result.button_title
             )
             and not final_result.new_message_chain
         )


### PR DESCRIPTION
## Summary
- 扩展模块化动作执行结果的 should_edit_message 判定逻辑，覆盖 next_menu_id、button_overrides 与 button_title 等更新
- 在工作流节点聚合中保留 button_title，并在最终结果中纳入新的判定条件

## Testing
- python - <<'PY' # 验证模块化动作仅返回 next_menu_id 时 should_edit_message 为 True
- python - <<'PY' # 验证工作流聚合结果包含 button_title 时 should_edit_message 为 True

------
https://chatgpt.com/codex/tasks/task_b_68f22cd9b3608326a3bd051efdb9e46a