### PR TITLE
feat: preserve context for redirected buttons

### DIFF
--- a/main.py
+++ b/main.py
@@ -190,6 +190,7 @@ class DynamicButtonFrameworkPlugin(Star):
         self.CALLBACK_PREFIX_BACK = "tgbtn:back:"
         self.CALLBACK_PREFIX_ACTION = "tgbtn:act:"
         self.CALLBACK_PREFIX_WORKFLOW = "tgbtn:wf:"
+        self.CALLBACK_PREFIX_REDIRECT = "tgbtn:redir:"
 
         logger.info(
             f"Dynamic button plugin loaded; menu command '/{self.menu_command}', WebUI={'enabled' if self.webui_enabled else 'disabled'}."


### PR DESCRIPTION
## Summary
- add a dedicated redirect callback prefix that encodes the source button and optional menu focus toggle
- update callback handling/runtime preparation to carry original menu context into execution results
- prefer the original menu when rebuilding markups after a redirect unless an explicit next menu is returned

## Testing
- python -m compileall handlers.py local_actions/redirect_button.py
- python - <<'PY' ... # manual redirect verification


------
https://chatgpt.com/codex/tasks/task_b_68f2350b594c8326babfcb6c5d21e81f